### PR TITLE
Fix module issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-import AnimationService from "./AnimationService";
-import config from "./config";
+import AnimationService from "./AnimationService.js";
+import config from "./config.js";
 
 export default class MundusBluetoothService {
   constructor() {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "Mundus PWA Bluetooth package",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mundus-tech/mundus-pwa-bluetooth",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Mundus PWA Bluetooth package",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
Fixes the following when using as a dependency in a fresh npm package:
- `import` syntax not recognized because the default type is `commonjs` which uses `require`
- files to import within the module cannot be found without file extensions

`node --version # v14.16.0`
`npm --version # 6.14.11`